### PR TITLE
Prevent calls to locateCharacteristic while not connected

### DIFF
--- a/ios/Classes/FlutterBluePlugin.m
+++ b/ios/Classes/FlutterBluePlugin.m
@@ -171,6 +171,13 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     NSString *remoteId = [call arguments];
     @try {
       CBPeripheral *peripheral = [self findPeripheral:remoteId];
+
+      if([peripheral state] != CBPeripheralStateConnected) {
+        NSLog(@"discoverServices ignoring non-connected peripheral");
+        result(nil);
+        return;
+      }
+
       // Clear helper arrays
       [_servicesThatNeedDiscovered removeAllObjects];
       [_characteristicsThatNeedDiscovered removeAllObjects ];
@@ -194,6 +201,13 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     @try {
       // Find peripheral
       CBPeripheral *peripheral = [self findPeripheral:remoteId];
+
+      if([peripheral state] != CBPeripheralStateConnected) {
+        NSLog(@"readCharacteristic ignoring non-connected peripheral");
+        result(nil);
+        return;
+      }
+
       // Find characteristic
       CBCharacteristic *characteristic = [self locateCharacteristic:[request characteristicUuid] peripheral:peripheral serviceId:[request serviceUuid] secondaryServiceId:[request secondaryServiceUuid]];
       // Trigger a read
@@ -209,6 +223,13 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     @try {
       // Find peripheral
       CBPeripheral *peripheral = [self findPeripheral:remoteId];
+
+      if([peripheral state] != CBPeripheralStateConnected) {
+        NSLog(@"readDescriptor ignoring non-connected peripheral");
+        result(nil);
+        return;
+      }
+
       // Find characteristic
       CBCharacteristic *characteristic = [self locateCharacteristic:[request characteristicUuid] peripheral:peripheral serviceId:[request serviceUuid] secondaryServiceId:[request secondaryServiceUuid]];
       // Find descriptor
@@ -225,6 +246,13 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     @try {
       // Find peripheral
       CBPeripheral *peripheral = [self findPeripheral:remoteId];
+
+      if([peripheral state] != CBPeripheralStateConnected) {
+        NSLog(@"writeCharacteristic ignoring non-connected peripheral");
+        result(nil);
+        return;
+      }
+
       // Find characteristic
       CBCharacteristic *characteristic = [self locateCharacteristic:[request characteristicUuid] peripheral:peripheral serviceId:[request serviceUuid] secondaryServiceId:[request secondaryServiceUuid]];
       // Get correct write type
@@ -242,6 +270,13 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     @try {
       // Find peripheral
       CBPeripheral *peripheral = [self findPeripheral:remoteId];
+
+      if([peripheral state] != CBPeripheralStateConnected) {
+        NSLog(@"writeDescriptor ignoring non-connected peripheral");
+        result(nil);
+        return;
+      }
+
       // Find characteristic
       CBCharacteristic *characteristic = [self locateCharacteristic:[request characteristicUuid] peripheral:peripheral serviceId:[request serviceUuid] secondaryServiceId:[request secondaryServiceUuid]];
       // Find descriptor
@@ -259,6 +294,13 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     @try {
       // Find peripheral
       CBPeripheral *peripheral = [self findPeripheral:remoteId];
+
+      if([peripheral state] != CBPeripheralStateConnected) {
+        NSLog(@"setNotification ignoring non-connected peripheral");
+        result(nil);
+        return;
+      }
+
       // Find characteristic
       CBCharacteristic *characteristic = [self locateCharacteristic:[request characteristicUuid] peripheral:peripheral serviceId:[request serviceUuid] secondaryServiceId:[request secondaryServiceUuid]];
       // Set notification value


### PR DESCRIPTION
Calls to a peripheral's services or characteristics after it has been disconnected are ignored with a small log. It is assumed that all of these calls will happen appropriately after a peripheral has reconnected. The calling code in Dart does not have an opportunity to handle state transition races, so this can't be 100% handled by writing correct client code.

Fixes https://github.com/pauldemarco/flutter_blue/issues/222, if due to calling read or write on a disconnected peripheral