### PR TITLE
Change CBCentralManager initialization

### DIFF
--- a/ios/Classes/FlutterBluePlugin.h
+++ b/ios/Classes/FlutterBluePlugin.h
@@ -12,6 +12,7 @@
 #define NAMESPACE @"plugins.pauldemarco.com/flutter_blue"
 
 @interface FlutterBluePlugin : NSObject<FlutterPlugin, CBCentralManagerDelegate, CBPeripheralDelegate>
++ (CBCentralManager*) prepCentralManager;
 @end
 
 @interface FlutterBlueStreamHandler : NSObject<FlutterStreamHandler>

--- a/lib/flutter_blue.dart
+++ b/lib/flutter_blue.dart
@@ -8,6 +8,7 @@ import 'dart:async';
 
 import 'package:collection/collection.dart';
 import 'package:convert/convert.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';

--- a/lib/src/bluetooth_characteristic.dart
+++ b/lib/src/bluetooth_characteristic.dart
@@ -99,12 +99,28 @@ class BluetoothCharacteristic {
     });
   }
 
+  // Attempt to read a value, gracefully handling
+  // * timeouts
+  // * inconsistent peripheral service discovery
+  Future<List<int>?> tryRead(Duration timeout) async {
+    try {
+      return read()
+          .then((d) => Future<List<int>?>.value(d))
+          .timeout(timeout, onTimeout: () => null);
+    } on PlatformException catch (e) {
+      if (e.code == "locateCharacteristic") {
+        debugPrint('Silencing $e');
+        return Future.value(null);
+      }
+    }
+  }
+
   /// Writes the value of a characteristic.
   /// [CharacteristicWriteType.withoutResponse]: the write is not
   /// guaranteed and will return immediately with success.
   /// [CharacteristicWriteType.withResponse]: the method will return after the
   /// write operation has either passed or failed.
-  Future<Null> write(List<int> value, {bool withoutResponse = false}) async {
+  Future<bool> write(List<int> value, {bool withoutResponse = false}) async {
     final type = withoutResponse
         ? CharacteristicWriteType.withoutResponse
         : CharacteristicWriteType.withResponse;
@@ -137,8 +153,25 @@ class BluetoothCharacteristic {
         .then((w) => w.success)
         .then((success) => (!success)
             ? throw new Exception('Failed to write the characteristic')
-            : null)
-        .then((_) => null);
+            : true)
+        .then((_) => true);
+  }
+
+  // Attempt to write a value, gracefully handling
+  // * timeouts
+  // * inconsistent peripheral service discovery
+  Future<bool?> tryWrite(List<int> value, Duration timeout,
+      {bool withoutResponse = false}) async {
+    try {
+      return write(value, withoutResponse: withoutResponse)
+          .then((b) => Future<bool?>.value(b))
+          .timeout(timeout, onTimeout: () => null);
+    } on PlatformException catch (e) {
+      if (e.code == "locateCharacteristic") {
+        debugPrint('Silencing $e');
+        return Future.value(null);
+      }
+    }
   }
 
   /// Sets notifications or indications for the value of a specified characteristic


### PR DESCRIPTION
The didFinishLaunchingWithOptions callback needs to check for the reason for launch and initialize the central manager during that hook.

The lookup for characteristics can be out of sync after state restoration, so tryRead and tryWrite provide a handler.

My AppDelegate looks like this now. Note the flutter_uploader package needed its own hooks installed.

```swift
import UIKit
import Flutter
import flutter_blue
import flutter_uploader

func registerPlugins(registry: FlutterPluginRegistry) {
  if (!registry.hasPlugin("FlutterUploaderPlugin")) {
    GeneratedPluginRegistrant.register(with: registry)
  }
}

@UIApplicationMain
@objc class AppDelegate: FlutterAppDelegate {
  override func application(
    _ application: UIApplication,
    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
  ) -> Bool {
    GeneratedPluginRegistrant.register(with: self)

    if launchOptions != nil && launchOptions![UIApplication.LaunchOptionsKey.bluetoothCentrals] != nil {
      // Initializes bluetooth after restore from terminated on CoreBluetooth event
      FlutterBluePlugin.prepCentralManager()
    }

    SwiftFlutterUploaderPlugin.registerPlugins = registerPlugins

    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
  }
}
```

I only use tryRead and tryWrite (no read or write).

```dart
final stateValue = await stateChar.tryRead(const Duration(seconds: 10));
if(stateValue == null) {
    // failed
} else {
    // success
}
```

I notice some weirdness on hot restarts, so unless it is a simple UI change, I don't hot restart/reload. I also sometimes notice 'Peripheral not found' errors when calling connect. I think the Obj-C lookup can be out of sync because of how it tracks peripherals and characteristics.