### PR TITLE
Fix some unexpected Android behavior across different make/model

### DIFF
--- a/ios/Classes/FlutterBluePlugin.m
+++ b/ios/Classes/FlutterBluePlugin.m
@@ -477,10 +477,8 @@ FlutterBluePlugin* INSTANCE = NULL;
 
   NSArray *peripherals = dict[CBCentralManagerRestoredStatePeripheralsKey];
   for(CBPeripheral *p in peripherals) {
-    p.delegate = self;
-    // [self.scannedPeripherals setObject:p forKey:[[p identifier] UUIDString]];
-    // ProtosScanResult *result = [self toScanResultProto:p advertisementData:@{} RSSI:0];
-    // [_channel invokeMethod:@"ScanResult" arguments:[self toFlutterData:result]];
+    [p setDelegate: self];
+    [p discoverServices: nil];
   } 
 
   _restoredPeripherals = [peripherals copy];
@@ -505,6 +503,9 @@ FlutterBluePlugin* INSTANCE = NULL;
 
   // Send connection state
   [_channel invokeMethod:@"DeviceState" arguments:[self toFlutterData:[self toDeviceStateProto:peripheral state:peripheral.state]]];
+
+  // Send name change
+  [_channel invokeMethod:@"DeviceConnected" arguments:[self toFlutterData:[self toDeviceProto:peripheral]]];
 }
 
 - (void)centralManager:(CBCentralManager *)central didDisconnectPeripheral:(CBPeripheral *)peripheral error:(NSError *)error {


### PR DESCRIPTION
I found that some issues on Motorola didn't happen on Pixel or Galaxy. Here are some of the fixes following some advice from this medium series: https://medium.com/@martijn.van.welie/making-android-ble-work-part-1-a736dcd53b02

Characteristic reads and writes are now serialized through a Queue and handled on a Handler on the main Looper. This fixes some crashes on different Android models.

Additionally, some models cache characteristics and negotiate different MTUs. By default, all local values in characteristics and descriptors are cleared on service discovery, and MTU is requested to 512 on connection.

Not in this PR: This train of debugging lead to finding potential cause to switch internals to use https://github.com/weliem/blessed-android or https://github.com/NordicSemiconductor/Android-BLE-Library that claim to fix these types of bugs.